### PR TITLE
shift randart naming weights around

### DIFF
--- a/crawl-ref/source/dat/database/randname.txt
+++ b/crawl-ref/source/dat/database/randname.txt
@@ -909,13 +909,8 @@ lapis lazuli
 
 glass
 
-clay
-
 w:2
 gossamer
-
-w:2
-vine
 %%%%
 _amulet material_
 

--- a/crawl-ref/source/dat/database/randname.txt
+++ b/crawl-ref/source/dat/database/randname.txt
@@ -75,10 +75,10 @@ of @player_doom@
 w:9
 of @death_or_doom@
 
-w:16
+w:4
 of @_strategy_or_justice_@
 
-w:4
+w:16
 of the @_people_name_@
 
 w:8
@@ -87,7 +87,7 @@ of the @_weapon_animal_@
 w:2
 of the @_plant_name_@
 
-w:7
+w:14
 of @_evil_stuff_@
 
 w:5
@@ -122,13 +122,13 @@ of @_magic_name_@
 w:5
 of @_substance_name_@
 
-w:7
+w:18
 of @_science_name_@
 
 w:5
 of @other_weapon_name@
 
-w:30
+w:16
 "@_plain_weapon_name_@"
 
 # general keywords (see rand_all.txt)
@@ -138,7 +138,7 @@ of @_time_name_@
 w:5
 of @_sky_or_light_@
 
-w:18
+w:7
 of @_virtue_or_vice_@
 
 of @_number_or_qualifier_@ @_thing_names_@
@@ -146,7 +146,7 @@ of @_number_or_qualifier_@ @_thing_names_@
 w:5
 of @_destiny_name_@
 
-w:9
+w:16
 of @god_name@'s @divine_esteem@
 
 # hardcoded keywords

--- a/crawl-ref/source/dat/database/randname.txt
+++ b/crawl-ref/source/dat/database/randname.txt
@@ -175,6 +175,7 @@ of @_armour_property_name_@
 w:20
 of @_wacky_armour_name_@
 
+w:30
 of the @_profession_name_@
 
 of @_politics_name_armour_@
@@ -191,13 +192,13 @@ of the @_celestial_bodies_@
 w:5
 of @_instrument_name_@
 
-w:20
+w:3
 of the @_armour_animal_@
 
 w:3
 of @_flower_name_@
 
-w:3
+w:20
 of the @_critter_name_@
 
 w:5
@@ -229,7 +230,6 @@ of @_time_name_@
 w:8
 of @_sky_or_light_@
 
-w:30
 of @_virtue_or_vice_@
 
 w:16
@@ -261,7 +261,7 @@ of @_suspicion_name_@
 # as defined for weapons (see rand_wpn.txt)
 of the @_people_name_@
 
-w:17
+w:5
 of @_balance_or_order_@
 
 w:14
@@ -279,7 +279,7 @@ of the @_armour_animal_@
 w:3
 of @_flower_name_@
 
-w:5
+w:17
 of @_evil_being_@
 
 w:20
@@ -305,10 +305,10 @@ of Xom's @_xom_esteem_@
 w:7
 of @_virtue_name_@
 
-w:13
+w:20
 of @_vice_name_@
 
-w:20
+w:13
 of @_number_or_qualifier_@ @_thing_names_@
 %%%%
 ######################################################
@@ -526,7 +526,7 @@ Xom armour
 w:5
 of @_chaos_name_@
 
-w:5
+w:1
 of Xom's @_xom_esteem_@
 
 w:2
@@ -536,7 +536,7 @@ of Xom's @divine_esteem@
 w:1
 of @xom_name@
 
-w:1
+w:5
 of @_game_name_@
 
 w:1
@@ -909,8 +909,13 @@ lapis lazuli
 
 glass
 
+clay
+
 w:2
 gossamer
+
+w:2
+vine
 %%%%
 _amulet material_
 


### PR DESCRIPTION
Without adding or removing any strings, this will change the "flavor" of hellcrawl randarts slightly by increasing the frequency of some previously-uncommon name categories, and decrease the frequency of some common ones.