### PR TITLE
ease the caps on spell knowledge

### DIFF
--- a/crawl-ref/source/defines.h
+++ b/crawl-ref/source/defines.h
@@ -160,7 +160,7 @@ const int MAX_SEC_ENCHANT = 2;
 // formula for MP from a potion of magic
 #define POT_MAGIC_MP (10 + random2avg(28, 3))
 
-const int MAX_KNOWN_SPELLS = 21;
+const int MAX_KNOWN_SPELLS = 26;
 
 const int INVALID_ABSDEPTH = -1000;
 

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -1356,7 +1356,7 @@ int player_hunger_rate(bool temp)
  */
 int player_total_spell_levels()
 {
-    return you.experience_level - 1 + you.skill(SK_SPELLCASTING, 2, true);
+    return you.experience_level + 1 + you.skill(SK_SPELLCASTING, 2, true);
 }
 
 /**


### PR DESCRIPTION
Because knowing spells can't be overpowered unless casting spells is overpowered. In which case, fix the spells, not the cramped spell knowledge limitations.