### PR TITLE
ignore `ls` aliases when building on mac

### DIFF
--- a/crawl-ref/source/Makefile
+++ b/crawl-ref/source/Makefile
@@ -432,7 +432,7 @@ endif
 
 # Find the oldest SDK available, in attempt to make this build as
 # backward-compatible as we possibly can.
-+SDK_VER := $(shell ls $(DEVELOPER_PATH)/SDKs | grep -v "MacOSX.sdk" | sort -n | head -1 | perl -pe 's/^MacOSX//g;s/.sdk$$//g')
+SDK_VER := $(shell command ls $(DEVELOPER_PATH)/SDKs | grep -v "MacOSX.sdk" | sort -n | head -1 | perl -pe 's/^MacOSX//g;s/.sdk$$//g')
 
 ifeq ($(SDK_VER),10.4u)
 SDK_VER := 10.4


### PR DESCRIPTION
I've tried a couple of times to build hellcrawl on mac (I'd go with the binaries if they were available, but i haven't seen any) and finally spent the time to look into it last night.

Turns out it was blocked because i have `alias ls=ls -F` in my `.bash_profile`.

Adding `command` to the `ls` line makes it ignore my aliases and ls like Dennis Ritchie intended.

Note -- I have no idea why removing the `+` from the start of the line was necessary -- it seems inconsistent with my understanding of that Makefile operator, from 5 minutes of reading -- but for some reason I had to remove it to make this work.

(it isn't super obvious in the github diff format -- I removed a `+` from the start of the line.)

Now it's building for me on my work laptop :)