### PR TITLE
Use normal as default difficulty

### DIFF
--- a/crawl-ref/source/newgame.cc
+++ b/crawl-ref/source/newgame.cc
@@ -1815,17 +1815,17 @@ static bool _choose_difficulty(newgame_def& ng, newgame_def& ng_choice,
 		switch(difficulty)
 		{
 		case 0:
-			tmp->set_fg_colour(GREEN);
-			tmp->add_hotkey('c');
-			tmp->set_id(DIFFICULTY_CASUAL);
-			text += "c - Casual";
-			break;
-		case 1:
 			tmp->set_fg_colour(WHITE);
 			tmp->add_hotkey('n');
 			tmp->set_id(DIFFICULTY_NORMAL);
 			text += "n - Normal";
 			freeform->set_active_item(tmp);
+			break;
+		case 1:
+			tmp->set_fg_colour(GREEN);
+			tmp->add_hotkey('c');
+			tmp->set_id(DIFFICULTY_CASUAL);
+			text += "c - Casual";
 			break;
 		}
 


### PR DESCRIPTION
Pressing Enter on the new game difficulty selection screen should
default to normal (not casual) difficulty.