### PR TITLE
Don't mark !lignification as dangerous

### DIFF
--- a/crawl-ref/source/itemname.cc
+++ b/crawl-ref/source/itemname.cc
@@ -3340,8 +3340,6 @@ bool is_dangerous_item(const item_def &item, bool temp)
     case OBJ_POTIONS:
         switch (item.sub_type)
         {
-        case POT_LIGNIFY:
-            return true;
         default:
             return false;
         }


### PR DESCRIPTION
This fixes a UI quirk where items marked as dangerous aren't picked up
by default due to how auto-identification is implemented. Now,
!lignification will be picked up by default, and players can disable it
in the '\' menu if they don't want it.