### PR TITLE
Remove stat zero

### DIFF
--- a/crawl-ref/source/output.cc
+++ b/crawl-ref/source/output.cc
@@ -915,9 +915,6 @@ static void _print_stats_hp(int x, int y)
 
 static short _get_stat_colour(stat_type stat)
 {
-    if (you.duration[stat_zero_duration(stat)])
-        return LIGHTRED;
-
     // Check the stat_colour option for warning thresholds.
     for (const auto &entry : Options.stat_colour)
         if (you.stat(stat) <= entry.first)

--- a/crawl-ref/source/player-reacts.cc
+++ b/crawl-ref/source/player-reacts.cc
@@ -690,18 +690,6 @@ static void _decrement_durations()
     if (you.duration[DUR_LIQUEFYING] && !you.stand_on_solid_ground())
         you.duration[DUR_LIQUEFYING] = 1;
 
-    for (int i = 0; i < NUM_STATS; ++i)
-    {
-        stat_type s = static_cast<stat_type>(i);
-        if (you.stat(s) > 0
-            && _decrement_a_duration(stat_zero_duration(s), delay))
-        {
-            mprf(MSGCH_RECOVERY, "Your %s has recovered.", stat_desc(s, SD_NAME));
-            you.redraw_stats[s] = true;
-        }
-    }
-
-
     if (you.duration[DUR_BERSERK]
         && you.hunger + 100 <= HUNGER_STARVING + BERSERK_NUTRITION)
     {

--- a/crawl-ref/source/player-stats.cc
+++ b/crawl-ref/source/player-stats.cc
@@ -32,7 +32,7 @@
 
 int player::stat(stat_type s, bool nonneg) const
 {
-    const int val = max_stat(s) - stat_loss[s];
+    const int val = max(1, max_stat(s) - stat_loss[s]);
     return nonneg ? max(val, 0) : val;
 }
 
@@ -605,16 +605,6 @@ static void _handle_stat_change(stat_type stat)
 {
     ASSERT_RANGE(stat, 0, NUM_STATS);
 
-    if (you.stat(stat) <= 0 && !you.duration[stat_zero_duration(stat)])
-    {
-        // Time required for recovery once the stat is restored, randomised slightly.
-        you.duration[stat_zero_duration(stat)] =
-            (20 + random2(20)) * BASELINE_DELAY;
-        mprf(MSGCH_WARN, "You have lost your %s.", stat_desc(stat, SD_NAME));
-        take_note(Note(NOTE_MESSAGE, 0, 0, make_stringf("Lost %s.",
-            stat_desc(stat, SD_NAME)).c_str()), true);
-    }
-
     you.redraw_stats[stat] = true;
     _normalize_stat(stat);
 
@@ -636,28 +626,4 @@ static void _handle_stat_change(stat_type stat)
     default:
         break;
     }
-}
-
-duration_type stat_zero_duration(stat_type stat)
-{
-    switch (stat)
-    {
-    case STAT_STR:
-        return DUR_COLLAPSE;
-    case STAT_INT:
-        return DUR_BRAINLESS;
-    case STAT_DEX:
-        return DUR_CLUMSY;
-    default:
-        die("invalid stat");
-    }
-}
-
-bool have_stat_zero()
-{
-    for (int i = 0; i < NUM_STATS; ++i)
-        if (you.duration[stat_zero_duration(static_cast<stat_type> (i))])
-            return true;
-
-    return false;
 }

--- a/crawl-ref/source/player-stats.h
+++ b/crawl-ref/source/player-stats.h
@@ -28,9 +28,5 @@ stat_type random_lost_stat();
 bool restore_stat(stat_type which_stat, int stat_gain,
                   bool suppress_msg, bool recovery = false);
 
-duration_type stat_zero_duration(stat_type stat);
-bool have_stat_zero();
-void update_stat_zero(int time);
-
 int innate_stat(stat_type s);
 #endif

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -2069,7 +2069,7 @@ int player_speed()
     if (you.cannot_act())
         return ps;
 
-    if (you.duration[DUR_SLOW] || have_stat_zero())
+    if (you.duration[DUR_SLOW])
         ps = haste_mul(ps);
 
     if (you.duration[DUR_BERSERK] && !have_passive(passive_t::no_haste))

--- a/crawl-ref/source/status.cc
+++ b/crawl-ref/source/status.cc
@@ -164,7 +164,6 @@ static void _describe_sickness(status_info* inf);
 static void _describe_speed(status_info* inf);
 static void _describe_poison(status_info* inf);
 static void _describe_transform(status_info* inf);
-static void _describe_stat_zero(status_info* inf, stat_type st);
 static void _describe_terrain(status_info* inf);
 static void _describe_missiles(status_info* inf);
 static void _describe_invisible(status_info* inf);
@@ -386,16 +385,6 @@ bool fill_status_info(int status, status_info* inf)
 
     case DUR_TRANSFORMATION:
         _describe_transform(inf);
-        break;
-
-    case STATUS_STR_ZERO:
-        _describe_stat_zero(inf, STAT_STR);
-        break;
-    case STATUS_INT_ZERO:
-        _describe_stat_zero(inf, STAT_INT);
-        break;
-    case STATUS_DEX_ZERO:
-        _describe_stat_zero(inf, STAT_DEX);
         break;
 
 #if TAG_MAJOR_VERSION == 34
@@ -933,7 +922,7 @@ static void _describe_poison(status_info* inf)
 
 static void _describe_speed(status_info* inf)
 {
-    bool slow = you.duration[DUR_SLOW] || have_stat_zero();
+    bool slow = you.duration[DUR_SLOW];
     bool fast = you.duration[DUR_HASTE] || you.attribute[ATTR_PERMAHASTE];
 
     if (slow && fast)
@@ -1022,21 +1011,6 @@ static void _describe_transform(status_info* inf)
 
     inf->light_colour = _dur_colour(GREEN, expire);
     _mark_expiring(inf, expire);
-}
-
-static const char* s0_names[NUM_STATS] = { "Collapse", "Brainless", "Clumsy", };
-
-static void _describe_stat_zero(status_info* inf, stat_type st)
-{
-    if (you.duration[stat_zero_duration(st)])
-    {
-        inf->light_colour = you.stat(st) ? LIGHTRED : RED;
-        inf->light_text   = s0_names[st];
-        inf->short_text   = make_stringf("lost %s", stat_desc(st, SD_NAME));
-        inf->long_text    = make_stringf(you.stat(st) ?
-                "You are recovering from loss of %s." : "You have no %s!",
-                stat_desc(st, SD_NAME));
-    }
 }
 
 static void _describe_terrain(status_info* inf)

--- a/crawl-ref/source/wiz-you.cc
+++ b/crawl-ref/source/wiz-you.cc
@@ -353,9 +353,6 @@ void wizard_heal(bool super_heal)
     you.redraw_hit_points = true;
     you.redraw_armour_class = true;
     you.redraw_evasion = true;
-
-    for (int stat = 0; stat < NUM_STATS; stat++)
-        you.duration[stat_zero_duration(static_cast<stat_type> (stat))] = 0;
 }
 
 void wizard_set_hunger_state()


### PR DESCRIPTION
Minimum stat value is now 1.

It's weirdly punishing to be stat zero vs 'stat one', and it doesn't
really change stat point allocation. The effect is basically to make
certain combos play excessively defensively around certain monsters
zones, like a MiBe in Tomb:3 (not that Tomb exists in Hellcrawl, but you
get the idea).

This makes negative stat mutations / randarts much less bad (when the
stat is your dump stat, anyway), so is certainly a player buff overall.