### PR TITLE
Remove a bunch of summoning spells

### DIFF
--- a/crawl-ref/source/book-data.h
+++ b/crawl-ref/source/book-data.h
@@ -43,7 +43,6 @@ static const vector<spell_type> spellbook_templates[] =
     SPELL_AURA_OF_ABJURATION,
     SPELL_SUMMON_DEMON,
     SPELL_SUMMON_FOREST,
-    SPELL_SUMMON_MANA_VIPER,
     SPELL_SHADOW_CREATURES,
 },
 
@@ -332,7 +331,6 @@ static const vector<spell_type> spellbook_templates[] =
 
 {   // Book of Beasts
     SPELL_SUMMON_ICE_BEAST,
-    SPELL_SUMMON_MANA_VIPER,
     SPELL_SUMMON_HYDRA,
 },
 

--- a/crawl-ref/source/book-data.h
+++ b/crawl-ref/source/book-data.h
@@ -340,7 +340,6 @@ static const vector<spell_type> spellbook_templates[] =
 },
 
 {   // Grand Grimoire
-    SPELL_MONSTROUS_MENAGERIE,
     SPELL_SUMMON_GREATER_DEMON,
     SPELL_MALIGN_GATEWAY,
     SPELL_SUMMON_HORRIBLE_THINGS,

--- a/crawl-ref/source/book-data.h
+++ b/crawl-ref/source/book-data.h
@@ -43,7 +43,6 @@ static const vector<spell_type> spellbook_templates[] =
     SPELL_AURA_OF_ABJURATION,
     SPELL_SUMMON_DEMON,
     SPELL_SUMMON_FOREST,
-    SPELL_SHADOW_CREATURES,
 },
 
 {   // Book of Fire
@@ -318,7 +317,6 @@ static const vector<spell_type> spellbook_templates[] =
     SPELL_HIBERNATION,
     SPELL_SILENCE,
     SPELL_DARKNESS,
-    SPELL_SHADOW_CREATURES,
 },
 
 {   // Book of Alchemy

--- a/crawl-ref/source/book-data.h
+++ b/crawl-ref/source/book-data.h
@@ -162,7 +162,6 @@ static const vector<spell_type> spellbook_templates[] =
     SPELL_SUMMON_SMALL_MAMMAL,
     SPELL_CALL_IMP,
     SPELL_SUMMON_GUARDIAN_GOLEM,
-    SPELL_SUMMON_LIGHTNING_SPIRE,
     SPELL_SUMMON_ICE_BEAST,
 },
 
@@ -184,7 +183,6 @@ static const vector<spell_type> spellbook_templates[] =
 },
 
 {   // Book of the Sky
-    SPELL_SUMMON_LIGHTNING_SPIRE,
     SPELL_AIRSTRIKE,
     SPELL_SILENCE,
     SPELL_DEFLECT_MISSILES,

--- a/crawl-ref/source/book-data.h
+++ b/crawl-ref/source/book-data.h
@@ -129,7 +129,6 @@ static const vector<spell_type> spellbook_templates[] =
     SPELL_OLGREBS_TOXIC_RADIANCE,
     SPELL_SUMMON_FOREST,
     SPELL_HYDRA_FORM,
-    SPELL_SUMMON_HYDRA,
 },
 
 #if TAG_MAJOR_VERSION > 34
@@ -329,7 +328,6 @@ static const vector<spell_type> spellbook_templates[] =
 
 {   // Book of Beasts
     SPELL_SUMMON_ICE_BEAST,
-    SPELL_SUMMON_HYDRA,
 },
 
 {   // Book of Annihilations

--- a/crawl-ref/source/book-data.h
+++ b/crawl-ref/source/book-data.h
@@ -9,7 +9,6 @@ static const vector<spell_type> spellbook_templates[] =
     SPELL_SLOW,
     SPELL_SUBLIMATION_OF_BLOOD,
     SPELL_CONJURE_FLAME,
-    SPELL_CALL_CANINE_FAMILIAR,
 },
 
 #if TAG_MAJOR_VERSION == 34
@@ -162,7 +161,6 @@ static const vector<spell_type> spellbook_templates[] =
 {   // Book of Callings
     SPELL_SUMMON_SMALL_MAMMAL,
     SPELL_CALL_IMP,
-    SPELL_CALL_CANINE_FAMILIAR,
     SPELL_SUMMON_GUARDIAN_GOLEM,
     SPELL_SUMMON_LIGHTNING_SPIRE,
     SPELL_SUMMON_ICE_BEAST,
@@ -335,7 +333,6 @@ static const vector<spell_type> spellbook_templates[] =
 },
 
 {   // Book of Beasts
-    SPELL_CALL_CANINE_FAMILIAR,
     SPELL_SUMMON_ICE_BEAST,
     SPELL_SUMMON_MANA_VIPER,
     SPELL_SUMMON_HYDRA,

--- a/crawl-ref/source/book-data.h
+++ b/crawl-ref/source/book-data.h
@@ -277,7 +277,6 @@ static const vector<spell_type> spellbook_templates[] =
 },
 
 {   // Book of Party Tricks
-    SPELL_SUMMON_BUTTERFLIES,
     SPELL_APPORTATION,
     SPELL_BECKONING,
     SPELL_TUKIMAS_DANCE,
@@ -336,7 +335,6 @@ static const vector<spell_type> spellbook_templates[] =
 },
 
 {   // Book of Beasts
-    SPELL_SUMMON_BUTTERFLIES,
     SPELL_CALL_CANINE_FAMILIAR,
     SPELL_SUMMON_ICE_BEAST,
     SPELL_SUMMON_MANA_VIPER,

--- a/crawl-ref/source/dat/descript/spells.txt
+++ b/crawl-ref/source/dat/descript/spells.txt
@@ -1450,7 +1450,7 @@ Calls forth a swarm of death scarabs.
 %%%%
 Summon Small Mammal spell
 
-Summons a small mammal to the caster's aid.
+Summons one or several small mammals to the caster's aid.
 %%%%
 Summon Spectral Orcs spell
 

--- a/crawl-ref/source/dat/descript/spells.txt
+++ b/crawl-ref/source/dat/descript/spells.txt
@@ -1388,9 +1388,9 @@ and the trees of the forest will be awakened to deal damage to nearby enemies.
 %%%%
 Summon Greater Demon spell
 
-Calls forth one of the greater demons of Pandemonium to serve the caster. With
-high power, the summoned demon will be less likely to be initially hostile —
-but the strongest demons may eventually turn against their summoner regardless.
+Calls forth one of the greater demons of Pandemonium to serve the caster. The
+greater the summoner's spell power, the less likely the demon will be to
+eventually break free of their bonds.
 %%%%
 Summon Guardian Golem spell
 

--- a/crawl-ref/source/enum.h
+++ b/crawl-ref/source/enum.h
@@ -3682,6 +3682,7 @@ MONS_ANTIMATTER_ELF,
     RANDOM_DEMON_LESSER,               //    0: Class V
     RANDOM_DEMON_COMMON,               //    1: Class III-IV
     RANDOM_DEMON_GREATER,              //    2: Class I-II
+    RANDOM_DEMON_GREATEST,             //    Class I only
     RANDOM_DEMON,                      //    any of the above
 
     RANDOM_MODERATE_OOD, // +5 depth, AKA '9' glyph on maps

--- a/crawl-ref/source/mon-place.cc
+++ b/crawl-ref/source/mon-place.cc
@@ -3368,6 +3368,9 @@ monster_type summon_any_demon(monster_type dct, bool use_local_demons)
         else
             return random_demon_by_tier(1);
 
+    case RANDOM_DEMON_GREATEST:
+        return random_demon_by_tier(1);
+
     default:
         return dct;
     }

--- a/crawl-ref/source/spl-data.h
+++ b/crawl-ref/source/spl-data.h
@@ -947,7 +947,7 @@ static const struct spell_desc spelldata[] =
     SPELL_SUMMON_GREATER_DEMON, "Summon Greater Demon",
     SPTYP_SUMMONING,
     SPFLAG_UNHOLY | SPFLAG_SELFENCH | SPFLAG_MONS_ABJURE,
-    7,
+    8,
     200,
     -1, -1,
     6, 0,

--- a/crawl-ref/source/spl-data.h
+++ b/crawl-ref/source/spl-data.h
@@ -385,7 +385,7 @@ static const struct spell_desc spelldata[] =
     SPTYP_SUMMONING,
     SPFLAG_NONE,
     1,
-    25,
+    200,
     -1, -1,
     1, 0,
     TILEG_SUMMON_SMALL_MAMMAL,
@@ -1431,12 +1431,12 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SUMMON_BUTTERFLIES, "Summon Butterflies",
     SPTYP_SUMMONING,
-    SPFLAG_NONE,
+    SPFLAG_MONSTER,
     1,
     100,
     -1, -1,
     1, 0,
-    TILEG_SUMMON_BUTTERFLIES,
+    TILEG_ERROR,
 },
 
 #if TAG_MAJOR_VERSION == 34

--- a/crawl-ref/source/spl-data.h
+++ b/crawl-ref/source/spl-data.h
@@ -1635,7 +1635,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_MONSTROUS_MENAGERIE, "Monstrous Menagerie",
     SPTYP_SUMMONING,
-    SPFLAG_MONS_ABJURE,
+    SPFLAG_MONS_ABJURE | SPFLAG_MONSTER,
     7,
     200,
     -1, -1,

--- a/crawl-ref/source/spl-data.h
+++ b/crawl-ref/source/spl-data.h
@@ -1363,7 +1363,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_CALL_CANINE_FAMILIAR, "Call Canine Familiar",
     SPTYP_SUMMONING,
-    SPFLAG_NONE,
+    SPFLAG_MONSTER,
     3,
     100,
     -1, -1,

--- a/crawl-ref/source/spl-data.h
+++ b/crawl-ref/source/spl-data.h
@@ -3300,7 +3300,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SUMMON_MANA_VIPER, "Summon Mana Viper",
     SPTYP_SUMMONING | SPTYP_HEXES,
-    SPFLAG_MONS_ABJURE,
+    SPFLAG_MONS_ABJURE | SPFLAG_MONSTER,
     5,
     100,
     -1, -1,

--- a/crawl-ref/source/spl-data.h
+++ b/crawl-ref/source/spl-data.h
@@ -1285,7 +1285,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SHADOW_CREATURES, "Shadow Creatures",
     SPTYP_SUMMONING,
-    SPFLAG_MONS_ABJURE,
+    SPFLAG_MONS_ABJURE | SPFLAG_MONSTER,
     6,
     0,
     -1, -1,

--- a/crawl-ref/source/spl-data.h
+++ b/crawl-ref/source/spl-data.h
@@ -2446,7 +2446,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SUMMON_HYDRA, "Summon Hydra",
     SPTYP_SUMMONING,
-    SPFLAG_MONS_ABJURE,
+    SPFLAG_MONS_ABJURE | SPFLAG_MONSTER,
     7,
     200,
     -1, -1,

--- a/crawl-ref/source/spl-data.h
+++ b/crawl-ref/source/spl-data.h
@@ -3164,7 +3164,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SUMMON_LIGHTNING_SPIRE, "Summon Lightning Spire",
     SPTYP_SUMMONING | SPTYP_AIR,
-    SPFLAG_TARGET | SPFLAG_NOT_SELF | SPFLAG_NEUTRAL,
+    SPFLAG_TARGET | SPFLAG_NOT_SELF | SPFLAG_NEUTRAL | SPFLAG_MONSTER,
     4,
     100,
     2, 2,

--- a/crawl-ref/source/spl-summoning.cc
+++ b/crawl-ref/source/spl-summoning.cc
@@ -1151,13 +1151,13 @@ static bool _summon_common_demon(int pow, god_type god, int spell, bool quiet)
 
 static bool _summon_greater_demon(int pow, god_type god, int spell, bool quiet)
 {
-    monster_type mon = summon_any_demon(RANDOM_DEMON_GREATER);
+    monster_type mon = summon_any_demon(RANDOM_DEMON_GREATEST);
 
-    const bool charmed = (random2(pow) > 5);
-    const bool friendly = (charmed && mons_demon_tier(mon) == 2);
+    // 0-90% chance of being friendly (as opposed to temporarily charmed)
+    const bool friendly = x_chance_in_y(pow, 220);
 
     return _summon_demon_wrapper(pow, god, spell, mon,
-                                 4, friendly, charmed, quiet);
+                                 4, friendly, true, quiet);
 }
 
 bool summon_demon_type(monster_type mon, int pow, god_type god,

--- a/crawl-ref/source/spl-summoning.cc
+++ b/crawl-ref/source/spl-summoning.cc
@@ -118,12 +118,22 @@ spret_type cast_summon_small_mammal(int pow, god_type god, bool fail)
 
     monster_type mon = MONS_PROGRAM_BUG;
 
-    if (x_chance_in_y(10, pow + 1))
-        mon = coinflip() ? MONS_BAT : MONS_RAT;
-    else
-        mon = MONS_QUOKKA;
+    // 1 - 10 mammals, about +1 every 20 power
+    const int adj_pow = pow - biased_random2(pow, 3);
+    dprf("Adjusted power is %d", adj_pow);
+    const int number = min(10, max(1, div_rand_round(adj_pow, 10)));
 
-    if (!create_monster(_pal_data(mon, 3, god, SPELL_SUMMON_SMALL_MAMMAL)))
+    bool success = false;
+    for (int i=0; i<number; i++) {
+        if (coinflip() || x_chance_in_y(10, pow + 1))
+            mon = coinflip() ? MONS_BAT : MONS_RAT;
+        else
+            mon = MONS_QUOKKA;
+        if (create_monster(_pal_data(mon, 3, god, SPELL_SUMMON_SMALL_MAMMAL)))
+            success = true;
+    }
+
+    if (!success)
         canned_msg(MSG_NOTHING_HAPPENS);
 
     return SPRET_SUCCESS;


### PR DESCRIPTION
Summoning school is pretty amazing in hellcrawl. I think it's oppressively amazing, in that it's so good any character investing in magic wants a significant chunk of XP in summoning, which makes all mage characters more homogenous than would be ideal.

There are a few problems:
* Hellcrawl changes have made summons better
* Summoning was already great
* There are a lot of summoning spells compared to other spell schools
* Lots of summoning spells aren't that different from one another

Here's what I think the solution should be:
* Most summon spells should be dual-school
* Summoning spells should be pared down to reduce redundancy
* Playing as a summoning-focused player should have a particular rhythm through the game where depending on the spell levels you're up to and spell schools you've branched into, you will have various strengths and weaknesses.

So this PR makes the following changes:

Level 1:
* Removed: Summon butterflies
* Modified: Summon Small Mammal. Spell power cap is 200. Summons 1-10 mammals based on on spellpower. Powerlevel at spellpower under 20 is basically the same. Above that level, it will fill the "summon spam" niche sbutterflies used to hold. Not as effectively, of course.

Level 2:
* Unchanged: Call Imp

Level 3:
* Removed: Canine Familiar. Comparing imps & canines, canines get SInv and a bit more health, imps get better damage. Removing canines opens up space for guardian golem to become a more used spell.
* Unchanged: Recall
* Unchanged: Guardian Golem

Level 4:
* Unchanged: Summon Ice Beast
* Removed: Summon Lightning Spire. This spell is really fun to use and micromanaging double zaps is good gameplay, but I think it encourages degenerate gameplay of its own as a result of its immobility/placeability. I would be open to removing summon ice beast instead of this one.

Level 5:
* Removed: Summon Mana Viper. Three level 5 summons is at least one too many. Mana Vipers were the most oppressively good so I chose to cut them.
* Unchanged: Summon Demon
* Unchanged: Summon Forest

Level 6:
* Removed: Shadow Creatures. Always been a finicky spell with lots of hidden spawn table minutiae affecting power

Level 7:
* Unchanged: Haunt (great spell)
* Unchanged: Malign Gateway (great spell)
* Unchanged: Spellforged Servitor (unique spell)
* Removed: Summon Hydra (boring)
* Removed: Monstrous menagerie (boring)

Level 8:
* Unchanged: Summon Horrible Things. Basically boring, but with the removal of Monstrous Menagerie we need at least one high level multi-summon.
* Modified: Summon Greater Demon. Bumped up from L7. Always summons a tier1 demon (was tier1 or 2). It's always initially friendly, but might become hostile before despawning based on spellpower (was not always initially friendly, and tier 1 summons always became hostile).

Level 9:
* Unchanged: Dragon's Call (would like to make this a permacharm)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hellmonk/hellcrawl/52)
<!-- Reviewable:end -->
