### PR TITLE
Set base player speed to 12

### DIFF
--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -1982,7 +1982,7 @@ int player_prot_life(bool calc_unid, bool temp, bool items)
 // want to go past 6 (see below). -- bwr
 int player_movement_speed()
 {
-    int mv = 10;
+    int mv = 12;
 
     // transformations
     if (you.form == TRAN_BAT)
@@ -1991,14 +1991,16 @@ int player_movement_speed()
         mv = 7;
     else if (you.form == TRAN_PORCUPINE)
         mv = 8;
-    else if (you.fishtail || you.form == TRAN_HYDRA && you.in_water())
+    else if (you.form == TRAN_HYDRA && you.in_water())
         mv = 6;
+    else if (you.fishtail)
+        mv -= 4;
 
     // moving on liquefied ground takes longer
     if (you.liquefied_ground())
         mv += 3;
 
-    // armour
+    // running ego
     if (you.run())
         mv -= 1;
 


### PR DESCRIPTION
Players being able to indefinitely kite / pillar dance the majority of
monsters is silly. Hellcrawl already has one change to prevent this: a
per-level doom timer, but it's a relatively long timer, and if you want
to spend 500 turns pillar dancing a monster to regenerate your health
nothing will stop you doing so.

Reducing the player's speed adds a much shorter upper limit to the
number of turns you can kite monsters. A speed of 12 vs 10 means it
will take five 'turns' for a typical monster to get a bonus move. This
seems like a reasonable trade-off between allowing monster pulling while
ensuring more degenerate tactics stop working.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hellmonk/hellcrawl/54)
<!-- Reviewable:end -->
